### PR TITLE
Implement inclusive date range filtering

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -91,20 +91,26 @@ async def handle_period(callback: CallbackQuery):
     now = datetime.now()
 
     if period == "today":
-        start_date = now.date()
+        start_date = end_date = now.date()
     elif period == "yesterday":
-        start_date = (now - timedelta(days=1)).date()
+        day = (now - timedelta(days=1)).date()
+        start_date = end_date = day
     elif period == "last_week":
-        start_date = (now - timedelta(days=7)).date()
+        current_week_start = (now - timedelta(days=now.weekday())).date()
+        start_date = current_week_start - timedelta(days=7)
+        end_date = current_week_start - timedelta(days=1)
     elif period == "last_month":
-        start_date = (now - timedelta(days=30)).date()
+        first_day_this_month = now.replace(day=1).date()
+        last_day_prev_month = first_day_this_month - timedelta(days=1)
+        start_date = last_day_prev_month.replace(day=1)
+        end_date = last_day_prev_month
     else:
         return await callback.message.answer("❌ Неверный период")
 
     await callback.message.answer("⏳ Начинаю обработку чеков...")
 
     link_data = load_link_data()
-    selected_links = get_links_for_period(start_date, link_data)
+    selected_links = get_links_for_period(start_date, end_date, link_data)
 
     # Создаём словарь {url: entry} без копирования объектов,
     # чтобы обновления статуса отражались в исходном списке

--- a/tests/test_get_links_for_period.py
+++ b/tests/test_get_links_for_period.py
@@ -1,0 +1,16 @@
+from datetime import date, timedelta
+
+from utils import get_links_for_period
+
+
+def test_get_links_for_period_inclusive():
+    today = date.today()
+    links = [
+        {"url": "yesterday", "date_str": (today - timedelta(days=1)).strftime("%d.%m.%Y")},
+        {"url": "today", "date_str": today.strftime("%d.%m.%Y")},
+        {"url": "future", "date_str": (today + timedelta(days=1)).strftime("%d.%m.%Y")},
+    ]
+
+    assert get_links_for_period(today, today, links) == ["today"]
+    assert get_links_for_period(today - timedelta(days=1), today - timedelta(days=1), links) == ["yesterday"]
+    assert get_links_for_period(today - timedelta(days=1), today, links) == ["yesterday", "today"]


### PR DESCRIPTION
## Summary
- Filter receipts by inclusive start/end dates
- Add precise period calculations for today, yesterday, last week, and last month
- Test date filtering to ensure correct range selection

## Testing
- `python -m py_compile bot.py utils.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896095671408331b4be93a73bfd6bd2